### PR TITLE
Refactor ClearCommand to ClearPersonCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -2,22 +2,30 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 
 /**
- * Clears the address book.
+ * Clears the model - person, or appointment.
  */
-public class ClearCommand extends Command {
+public abstract class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
-
+    public static final String MESSAGE_USAGE = "clear person OR clear appt";
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.setAddressBook(new AddressBook());
-        return new CommandResult(MESSAGE_SUCCESS);
+        clearEntity(model);
+        return new CommandResult(getSuccessMessage());
     }
+
+    /*
+     * Clears a specified model.
+     */
+    protected abstract void clearEntity(Model model);
+
+    /*
+     * Returns success message to display upon adding entity.
+     */
+    protected abstract String getSuccessMessage();
 }

--- a/src/main/java/seedu/address/logic/commands/ClearPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearPersonCommand.java
@@ -1,0 +1,23 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+
+/**
+ * Clears the address book.
+ */
+public class ClearPersonCommand extends ClearCommand {
+
+    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+
+    protected void clearEntity(Model model) {
+        model.setAddressBook(new AddressBook());
+    }
+
+    /*
+     * Returns success message to display upon adding entity.
+     */
+    protected String getSuccessMessage() {
+        return MESSAGE_SUCCESS;
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -64,7 +64,7 @@ public class AddressBookParser {
             return new DeleteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+            return new ClearCommandParser().parse(arguments);
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.ParserUtil.APPOINTMENT_ENTITY_STRING;
+import static seedu.address.logic.parser.ParserUtil.PERSON_ENTITY_STRING;
+
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.ClearPersonCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ClearCommand object
+ */
+public class ClearCommandParser implements Parser<ClearCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the ClearCommand
+     * and returns a ClearCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ClearCommand parse(String args) throws ParseException {
+
+        String entityType = args.trim();
+
+        switch (entityType) {
+        case PERSON_ENTITY_STRING:
+            return new ClearPersonCommand();
+        case APPOINTMENT_ENTITY_STRING:
+            //TODO: Instantiate and return ClearAppointmentCommand
+        default:
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    ClearCommand.MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -17,7 +17,7 @@ public class ClearCommandTest {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
 
-        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ClearPersonCommand(), model, ClearPersonCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
@@ -26,7 +26,7 @@ public class ClearCommandTest {
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel.setAddressBook(new AddressBook());
 
-        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ClearPersonCommand(), model, ClearPersonCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -166,7 +166,7 @@ public class EditCommandTest {
         assertFalse(standardCommand.equals(null));
 
         // different types -> returns false
-        assertFalse(standardCommand.equals(new ClearCommand()));
+        assertFalse(standardCommand.equals(new ClearPersonCommand()));
 
         // different index -> returns false
         assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PERSON, DESC_AMY)));

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -42,9 +42,15 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_clear() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+    public void parseCommand_clearPersonCommand() throws Exception {
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD
+                +
+                " "
+                + ParserUtil.PERSON_ENTITY_STRING) instanceof ClearCommand);
+        /* ToDo: Make this work
+             assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD +
+                " " + ParserUtil.PERSON_ENTITY_STRING + " 3") instanceof ClearCommand);
+                */
     }
 
     @Test


### PR DESCRIPTION
Resolves #53.

Refactored clear command.

Currently, the original behaviour of `clear person 3` is not working. Do we need to retain this functionality, or not?