### PR TITLE
Change instruction to running java -jar instead of double click

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -957,7 +957,7 @@ testers are expected to do more *exploratory* testing.
 
 2. Saving window preferences
    1. Resize the window to an optimum size. Move the window to a different location. Close the window.
-   2. Re-launch the app by double-clicking the jar file.<br>
+   2. Re-launch the app by running the command: `java -jar DocTrack.jar`.<br>
        Expected: The most recent window size and location is retained.
 
 ### Adding a person


### PR DESCRIPTION
Resolves #258 