### PR TITLE
Fix delete person before edit bug

### DIFF
--- a/src/main/java/seedu/address/model/AppointmentBook.java
+++ b/src/main/java/seedu/address/model/AppointmentBook.java
@@ -129,7 +129,6 @@ public class AppointmentBook implements ReadOnlyAppointmentBook {
      */
     public void setAppointment(Appointment target, Appointment editedAppointment) {
         requireNonNull(editedAppointment);
-
         appointments.setAppointment(target, editedAppointment);
     }
 

--- a/src/main/java/seedu/address/model/appointment/UniqueAppointmentList.java
+++ b/src/main/java/seedu/address/model/appointment/UniqueAppointmentList.java
@@ -125,7 +125,7 @@ public class UniqueAppointmentList implements Iterable<Appointment> {
      */
     public void removeAppointmentsForPerson(Person toRemove) {
         requireNonNull(toRemove);
-        internalList.removeIf(appointment -> appointment.getPerson().equals(toRemove));
+        internalList.removeIf(appointment -> appointment.getPersonId() == toRemove.getPersonId());
     }
 
     /**


### PR DESCRIPTION
Resolves #263 

In the User Guide, the desired behaviour is deletion of a person, results in deletion of the appointments.

<img width="913" alt="image" src="https://github.com/user-attachments/assets/dabe0c7b-c81a-4d6e-a5fe-37820b156909">

This was previously implemented, but with the wrong parameter, using `Person::equals` to get the list of appointments for that person, instead of an equality of the personId.

<img width="802" alt="image" src="https://github.com/user-attachments/assets/140ca2f2-5596-4ed3-9599-3ca6642332ce">

This has been changed to checking the personId.

